### PR TITLE
[Feature] Added image viewer to blog pages with shortcodes

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,6 +37,22 @@
   <section id="search-content" class="py-2">
     <div class="container" id="search-results"></div>
   </section>
+
+ <!-- Script for image viewer to be loaded in most pages. -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.3/viewer.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    new Viewer(document.body, {
+      filter(image) {
+        return image.classList.contains('zoomable-img');
+      },
+      toolbar: true,
+      title: true,
+      zoomable: true,
+      scalable: true,
+    });
+  });
+</script>
 </body>
 
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,6 +3,8 @@
 <link rel="stylesheet" href="{{ `css/single.css` | relURL }}?v={{ now.Unix }}" media="all">
 <!-- fontawesome -->
 <script src="{{ `fontawesome-6/all-6.4.2.js` | relURL}}"></script>
+<!-- Image viewer-->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.3/viewer.min.css" />
 {{ end }}
 
 {{ define "title" }}

--- a/layouts/shortcodes/zooming.html
+++ b/layouts/shortcodes/zooming.html
@@ -1,0 +1,12 @@
+<!--  Added a figure shortcode to group images together -->
+<figure style="margin: 1.5rem auto; text-align: center;">
+  <!-- Adds logic to retrieve params from shortcode {.Get "tag"} 
+    and added a css class "zoomable-img" to be styled in single.css -->
+  <img src="{{ .Get "src" }}" alt="{{ .Get "alt" }}" class="zoomable-img"
+    style="max-width: 100%; height: auto; border-radius: 8px;">
+  {{ with .Get "caption" }}
+    <figcaption style="font-size: 0.9rem; color: #aaa; margin-top: 0.5rem;">
+      {{ . }}
+    </figcaption>
+  {{ end }}
+</figure>

--- a/static/css/single.css
+++ b/static/css/single.css
@@ -357,4 +357,29 @@
     border-radius: 4px;
     font-style: italic;
 }
+
+/*  Styles the container holding all images  */
+.gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem; 
+    justify-content: center; 
+}
+
+/*  Styles the image wrapper (Figure) */
+.gallery figure {
+    flex-grow: 1;   /*  Allows imgs to fill space proportionally */
+    flex-shrink: 1; /*  Allows imgs to shrink to fit on 1 line*/
+    flex-basis: 0;  /*  Starts at 0 width to allow resizing to best fit the row*/
+    margin: 0;
+}
+
+/*  Styles the images inside of the figure */
+.gallery img {
+    width: 100%;
+    height: 250px !important;  /*  Used to Have the imgs at a baseline height */
+    object-fit: cover;       /* crop image to fill box */
+    border-radius: 8px;
+    cursor: pointer;
+}
 /* Singlepage scroll progress end */


### PR DESCRIPTION
# No more tedious image insertion
Got really annoyed at manually adding in images and fighting to adjust the width. I decided to use a hugo shortcode instead. Here's what the code looked like before
```css
<div style="display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;">
  <div style="text-align: center; flex: 1 1 300px; max-width: 40%;">
    <a href="/github-portfolio/images/esp_ecg_blog/MAC-5.jpg">
      <img src="/github-portfolio/images/esp_ecg_blog/MAC-5.jpg" alt="My solder job" style="width: 100%; border-radius: 8px;">
      <p style="font-size: 14px;">A GE MAC-5 ECG machine</p>
    </a>
  </div>
</div>
```
Here it is now
```css
{{< zooming src="/github-portfolio/images/esp_dsp_blog/r.png" alt="Zoomable image" caption="Click to zoom" >}}
```
with gallery (multiple image) support too
```css
<div class="gallery">
{{< zooming src="/github-portfolio/images/esp_dsp_blog/r.png" alt="Zoomable image" caption="Click to zoom" >}}
{{< zooming src="/github-portfolio/images/esp_dsp_blog/g.webp" alt="Zoomable image" caption="Click to zoom" >}}
{{< zooming src="/github-portfolio/images/esp_dsp_blog/b.png" alt="Zoomable image" caption="Click to zoom" >}}
</div>
```
Here's the end result(s)
<img width="998" height="329" alt="image" src="https://github.com/user-attachments/assets/8188f41e-4648-4b90-8542-a26ae2d47321" />
![image](https://github.com/user-attachments/assets/8605ffa1-182f-46a3-a99d-92e95bb6a04c)
