### PR TITLE
[Fix + Refactor] Got highlights to work within the main page

### DIFF
--- a/layouts/partials/sections/contact.html
+++ b/layouts/partials/sections/contact.html
@@ -1,7 +1,11 @@
 {{ if .Site.Params.contact.enable | default false }}
 <section id="contact" class="py-5">
     <div class="container">
-        <h1 class="text-center cerulean-blue-text">{{ .Site.Params.contact.title | default "Get in Touch" }}</h1>
+        <h1 class="text-center bg-transparent">
+            <span class="jonquil-yellow-highlight">
+                {{ .Site.Params.contact.title | default "Get in Touch" }}
+            </span>
+        </h1>
         <div class="px-0 px-md-5 px-lg-5">
             <div class="row justify-content-center px-md-5">
                 <div class="col-md-8 py-3">

--- a/layouts/partials/sections/experience.html
+++ b/layouts/partials/sections/experience.html
@@ -3,7 +3,11 @@
 {{ if .Site.Params.experience.enable | default false }}
 <section id="experience" class="py-5">
     <div class="container">
-        <h1 class="text-center bg-transparent jonquil-yellow-highlight">{{ .Site.Params.experience.title | default "Experience" }}</h1>
+        <h1 class="text-center bg-transparent">
+            <span class="gold-highlight">
+                {{ .Site.Params.experience.title | default "Experience" }}
+            </span>
+        </h1>
         <div class="row justify-content-center">
             <div class="col-sm-12 col-md-8 col-lg-8 py-5">
                 <div class="experience-container px-3 pt-2">

--- a/static/css/experience.css
+++ b/static/css/experience.css
@@ -1,0 +1,8 @@
+#experience .gold-highlight {
+    background-color: #FFDB58 !important; /* MUSTAARRDDD Yellow */
+    color: black;
+    font-weight: bold;
+    padding: 1px 1px;
+    border-radius: 4px;
+    font-style: italic;
+}


### PR DESCRIPTION
There was a highlight in [This file](https://github.com/Sudo-Victor-Victory/github-portfolio/blob/eee51a224d66087fcce9cb188ded9831e41df51b/layouts/partials/sections/experience.html) 2 commits ago that contained a highlight but did not get rendered properly. That was because  the header it was attached to contained ` bg-transparent ` which removed the background.

After removing that, I uncovered that the reason why it was hidden was to prevent a background from stretching across the entire row.
So to solve it, I simply wrapped it in a span which kept it contained. Yippe!